### PR TITLE
bump egui versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,6 @@ quad-storage-sys = { path = "quad-storage-sys", version = "0.1.0" }
 nanoserde = "0.1.29"
 
 [dev-dependencies]
-egui-macroquad = "0.5.0"
+egui-macroquad = "0.12.0"
 macroquad = "0.3.7"
-egui = "0.13.1"
+egui = "0.19"


### PR DESCRIPTION
Nice library :)
I get compilation errors on Fedora 35 which might could be resolved by changing or adding other mesa packages but an upgrade of egui and macroquad-egui also solves this issue.