### PR TITLE
Add ios support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
 
 [dependencies]
 lazy_static = "1.4.0"
+objc = "0.2.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 quad-storage-sys = { path = "quad-storage-sys", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = [
 
 [dependencies]
 lazy_static = "1.4.0"
+[target.'cfg(target_os = "ios")'.dependencies]
 objc = "0.2.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Hello, thanks for providing quad-storage!

This adds support for iOS devices by writing the file to the `NSDocumentDirectory` of the device. On iOS we are not allowed to write to the directory of the app.

Another way to support this, that I considered, is to provide a “constructor” that accepts the path of a storage file and let the consumer of quad-storage deal with ios specific things. However, it seemed to me to be in the “promise” of something called quad-storage to just handle storage wherever Macroquad goes. WDYT?