### PR TITLE
bump to ver 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quad-storage"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Ilya Sheprut <optozorax@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/docs/quad-storage.js
+++ b/docs/quad-storage.js
@@ -37,5 +37,5 @@ miniquad_add_plugin({
     register_plugin: params_register_js_plugin,
     on_init: params_set_mem,
     name: "quad_storage",
-    version: "0.1.2"
+    version: "0.1.4"
 });

--- a/js/quad-storage.js
+++ b/js/quad-storage.js
@@ -37,5 +37,5 @@ miniquad_add_plugin({
     register_plugin: params_register_js_plugin,
     on_init: params_set_mem,
     name: "quad_storage",
-    version: "0.1.2"
+    version: "0.1.4"
 });


### PR DESCRIPTION
gets a new crate version prepared to release the dev-dependencies being updated to a working version on modern machines

I tested that the WASM build still works

Let me know if I missed anythign with the upgrade process, I'm not totally confident with what needs to be done. Thanks!
